### PR TITLE
(WIP) FaqItem: smooth transition of FAQ block

### DIFF
--- a/components/FaqItem.vue
+++ b/components/FaqItem.vue
@@ -68,7 +68,7 @@
       </div>
       <h4 class="title">{{ title }}</h4>
     </div>
-    <transition name="slide-fade">
+    <transition v-on:before-enter="getFaqHeight" v-on:enter="slideDown" v-on:leave="slideUp" name="slide-fade">
       <div v-if="open" class="answer">
         <slot/>
       </div>
@@ -83,12 +83,40 @@ export default {
   },
   data() {
     return {
-      open: false
+      open: false,
+      faqHeight: 0
     }
   },
   computed: {
     arrowDirection() {
       return this.open ? 'right' : 'down'
+    }
+  },
+  methods: {
+    getFaqHeight: function() {
+      const faq = this.$el.closest('.faq')
+      this.faqHeight = faq.clientHeight
+      faq.style.height = `${this.faqHeight}px`
+    },
+    slideDown: function() {
+      const faq = this.$el.closest('.faq')
+      const old = this.faqHeight
+      const now = faq.scrollHeight
+      if (old < now) {
+        window.requestAnimationFrame(() => {
+          faq.style.transition = '0.25s linear'
+
+          window.requestAnimationFrame(() => {
+            faq.style.height = `${now}px`
+          })
+        })
+      } else {
+        faq.style.height = 'auto'
+      }
+    },
+    slideUp: function() {
+      const faq = this.$el.closest('.faq')
+      faq.style.height = 'auto'
     }
   }
 }


### PR DESCRIPTION
Adds a smooth height transition of the FAQ block
when an answer that causes it to grow is opened.

CSS transitions for height: auto are [currently impossible](https://stackoverflow.com/questions/3508605/how-can-i-transition-height-0-to-height-auto-using-css/3512194#3512194), so a JS solution is implemented.
Sliding down works fine, still working on sliding up due to some quirks and lack of free time 😢.

Fixes: https://github.com/VandyHacks/VHF2017-website/issues/3